### PR TITLE
BREAKING CHANGE: deliver to full text on feed reader

### DIFF
--- a/src/feed/feedValue.ts
+++ b/src/feed/feedValue.ts
@@ -34,7 +34,7 @@ export function createFeedValue(entries: readonly EntryValue[], metadata: WebSit
 
     return {
       title: entry.title,
-      description: entry.excerpt,
+      description: entry.body,
       pubDate,
       link,
     };


### PR DESCRIPTION
This commit is a breaking change. The reason is deliver partial text to full text
on feed readers.