### PR TITLE
feat: change likes POST API implements

### DIFF
--- a/src/features/likes/api/likeActions.test.ts
+++ b/src/features/likes/api/likeActions.test.ts
@@ -55,41 +55,47 @@ describe('likeActions', () => {
     });
   });
 
-  describe('upsertLikeCounts', () => {
+  describe('incrementLikeCounts', () => {
     it('inserts when entryId is not registered in db', async () => {
       // Arrange
       mockDb.insert.mockReturnValue({
         values: vi.fn().mockReturnValue({
-          onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          onConflictDoUpdate: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ counts: 1 }]),
+          }),
         }),
       });
 
       // Act
-      await likeActions.upsertLikeCounts({
+      const result = await likeActions.incrementLikeCounts({
         entryId: 'entry1',
-        counts: 1,
+        increment: 1,
       });
 
       // Assert
       expect(mockDb.insert).toHaveBeenCalled();
+      expect(result).toBe(1);
     });
 
     it('updates when entryId is registered in db', async () => {
       // Arrange
       mockDb.insert.mockReturnValue({
         values: vi.fn().mockReturnValue({
-          onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          onConflictDoUpdate: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ counts: 5 }]),
+          }),
         }),
       });
 
       // Act
-      await likeActions.upsertLikeCounts({
+      const result = await likeActions.incrementLikeCounts({
         entryId: 'entry1',
-        counts: 2,
+        increment: 3,
       });
 
       // Assert
       expect(mockDb.insert).toHaveBeenCalled();
+      expect(result).toBe(5);
     });
   });
 });

--- a/src/features/likes/api/likesApiValidationSchema.ts
+++ b/src/features/likes/api/likesApiValidationSchema.ts
@@ -1,16 +1,15 @@
 import { type InferOutput, integer, minValue, number, object, pipe, string } from 'valibot';
 
 export const likesRequestSchema = object({
-  counts: pipe(
-    number('Counts must be a number'),
-    integer('Counts must be an integer'),
-    minValue(1, 'Counts must be at least 1'),
+  increment: pipe(
+    number('Increment must be a number'),
+    integer('Increment must be an integer'),
+    minValue(1, 'Increment must be at least 1'),
   ),
 });
 
 export const likesResponseSchema = object({
-  id: string('ID must be a string'),
-  counts: pipe(number('Counts must be a number'), integer('Counts must be an integer')),
+  message: string('Message must be a string'),
 });
 
 export type LikesResponse = InferOutput<typeof likesResponseSchema>;

--- a/src/features/likes/hooks/likes_buffer/internals/storage.ts
+++ b/src/features/likes/hooks/likes_buffer/internals/storage.ts
@@ -8,10 +8,10 @@ const storage = getDOMStorage().session;
 /**
  * Saves a failed request to the retry queue.
  */
-export function saveToRetryQueue(entryId: string, counts: number): void {
+export function saveToRetryQueue(entryId: string, increment: number): void {
   try {
     const queue = JSON.parse(storage.getItem(LIKE_SEND_RETRY_QUEUE_KEY) || '[]') as RetryQueueItem[];
-    queue.push({ entryId, counts, timestamp: Date.now() });
+    queue.push({ entryId, increment, timestamp: Date.now() });
     storage.setItem(LIKE_SEND_RETRY_QUEUE_KEY, JSON.stringify(queue));
   } catch (error) {
     console.error('Failed to save to retry queue:', error);
@@ -24,7 +24,7 @@ export function saveToRetryQueue(entryId: string, counts: number): void {
       },
       extra: {
         entryId,
-        counts,
+        increment,
       },
     });
   }

--- a/src/features/likes/hooks/likes_buffer/internals/types.ts
+++ b/src/features/likes/hooks/likes_buffer/internals/types.ts
@@ -1,6 +1,6 @@
 export interface RetryQueueItem {
   entryId: string;
-  counts: number;
+  increment: number;
   timestamp: number;
 }
 

--- a/src/features/likes/hooks/likes_buffer/internals/types.ts
+++ b/src/features/likes/hooks/likes_buffer/internals/types.ts
@@ -4,5 +4,5 @@ export interface RetryQueueItem {
   timestamp: number;
 }
 
-export const FLUSH_TIMER = 3000 as const;
+export const FLUSH_TIMER = 1000 as const;
 export const LIKE_SEND_RETRY_QUEUE_KEY = 'likeRetryQueue' as const;

--- a/src/features/likes/hooks/likes_buffer/useLikesBuffer.test.ts
+++ b/src/features/likes/hooks/likes_buffer/useLikesBuffer.test.ts
@@ -18,12 +18,11 @@ describe('useLikesBuffer', () => {
     vi.clearAllTimers();
   });
 
-  it('should add counts with counts is 1', async () => {
+  it('should add increment with increment is 1', async () => {
     // Arrange
     const server = setupServer(
-      http.post('/api/likes/:id', ({ params }) => {
-        const { id } = params;
-        return HttpResponse.json({ id, counts: 1 });
+      http.post('/api/likes/:id', () => {
+        return HttpResponse.json({ message: 'Like count incremented by 1. New count: 1' });
       }),
     );
     server.listen();
@@ -42,12 +41,11 @@ describe('useLikesBuffer', () => {
     server.close();
   });
 
-  it('should add counts with counts is 3', async () => {
+  it('should add increment with increment is 3', async () => {
     // Arrange
     const server = setupServer(
-      http.post('/api/likes/:id', ({ params }) => {
-        const { id } = params;
-        return HttpResponse.json({ id, counts: 3 });
+      http.post('/api/likes/:id', () => {
+        return HttpResponse.json({ message: 'Like count incremented by 3. New count: 3' });
       }),
     );
     server.listen();

--- a/src/features/likes/hooks/useLikes.test.ts
+++ b/src/features/likes/hooks/useLikes.test.ts
@@ -5,7 +5,7 @@ vi.mock('./likes_buffer/buffer', () => ({
   })),
 }));
 vi.mock('./likes_buffer/internals/api', () => ({
-  sendLikes: vi.fn(() => Promise.resolve({ counts: 1 })),
+  sendLikes: vi.fn(() => Promise.resolve({ message: 'OK' })),
 }));
 vi.mock('./likes_buffer/internals/storage', () => ({
   clearRetryQueue: vi.fn(),
@@ -28,6 +28,7 @@ describe('useLikes', () => {
     });
 
     // Assert
+
     expect(result.current.counts).toBe(1);
   });
 });

--- a/src/features/likes/hooks/useLikes.ts
+++ b/src/features/likes/hooks/useLikes.ts
@@ -46,9 +46,8 @@ export function useLikes({ entryId }: UseLikeParams): UseLikeReturn {
   countsRef.current = counts;
 
   const handleLikes = useCallback(() => {
-    const newCounts = countsRef.current + 1;
-    void mutate({ id: entryId, counts: newCounts }, { revalidate: false });
-    updateLikeCounts(entryId, newCounts);
+    void mutate({ id: entryId, counts: countsRef.current + 1 }, { revalidate: false });
+    updateLikeCounts(entryId, 1);
   }, [entryId, mutate, updateLikeCounts]);
 
   return {

--- a/src/pages/api/likes/[id].ts
+++ b/src/pages/api/likes/[id].ts
@@ -2,7 +2,7 @@ import type { APIContext } from 'astro';
 import { DrizzleQueryError } from 'drizzle-orm';
 import { parse, ValiError } from 'valibot';
 
-import { getLikeCounts, upsertLikeCounts } from '../../../features/likes/api/likeActions';
+import { getLikeCounts, incrementLikeCounts } from '../../../features/likes/api/likeActions';
 import { likesRequestSchema } from '../../../features/likes/api/likesApiValidationSchema';
 import { checkRateLimit } from '../../../features/likes/utils/rateLimiter';
 
@@ -83,12 +83,10 @@ export async function GET({ locals, params }: APIContext): Promise<Response> {
 
 export async function POST({ locals, params, request }: APIContext): Promise<Response> {
   const { id } = params;
-
   if (id == null || id === '') {
     return new Response(
       JSON.stringify({
-        error: 'Invalid Entry ID',
-        details: null,
+        message: 'Invalid Entry ID',
       }),
       { status: 400 },
     );
@@ -109,8 +107,7 @@ export async function POST({ locals, params, request }: APIContext): Promise<Res
   if (request.body == null) {
     return new Response(
       JSON.stringify({
-        error: 'Request body must be valid JSON format',
-        details: null,
+        message: 'Request body must be valid JSON format',
       }),
       { status: 400 },
     );
@@ -119,30 +116,37 @@ export async function POST({ locals, params, request }: APIContext): Promise<Res
   try {
     const requestBody = await request.json();
     const validatedData = parse(likesRequestSchema, requestBody);
-    const counts = validatedData.counts;
+    const increment = validatedData.increment;
 
-    await upsertLikeCounts({
+    if (increment < 0) {
+      return new Response(
+        JSON.stringify({
+          message: 'Increment must be positive value',
+        }),
+        { status: 400 },
+      );
+    }
+
+    await incrementLikeCounts({
       context: locals,
-      counts,
+      increment,
       entryId: id,
     });
 
     return new Response(
       JSON.stringify({
-        id,
-        counts,
+        message: 'OK',
       }),
       { status: 200 },
     );
   } catch (error) {
     if (error instanceof ValiError) {
+      const messages = error.issues
+        .map((issue: { path?: Array<{ key?: string }>; message: string }) => issue.message)
+        .join(', ');
       return new Response(
         JSON.stringify({
-          error: 'Validation error',
-          details: error.issues.map((issue: { path?: Array<{ key?: string }>; message: string }) => ({
-            path: issue.path?.map((p) => p.key ?? '').join('.') ?? '',
-            message: issue.message,
-          })),
+          message: `Validation error: ${messages}`,
         }),
         { status: 400 },
       );
@@ -154,8 +158,7 @@ export async function POST({ locals, params, request }: APIContext): Promise<Res
 
     return new Response(
       JSON.stringify({
-        error: 'Internal server error',
-        details: null,
+        message: 'Internal server error',
       }),
       { status: 500 },
     );


### PR DESCRIPTION
## Summary

The previous like POST API allowed to freely set values ​​(integer only) for counts.

This means that can freely rewrite existing like counts.

To prevent rewrite the likes counts, it send the value to be added.

## References

- https://github.com/kubosho/blog.kubosho.com/issues/2466