### PR TITLE
fix: add maximum limit of 100 to increment value

### DIFF
--- a/app/src/features/likes/api/likesApiValidationSchema.test.ts
+++ b/app/src/features/likes/api/likesApiValidationSchema.test.ts
@@ -1,0 +1,83 @@
+import { safeParse } from 'valibot';
+import { describe, expect, it } from 'vitest';
+
+import { likesOnPostRequestSchema, MAX_INCREMENT_VALUE } from './likesApiValidationSchema';
+
+describe('likesOnPostRequestSchema', () => {
+  describe('increment field', () => {
+    it('accepts valid increment value of 1', () => {
+      // Arrange
+      const input = { increment: 1 };
+
+      // Act
+      const result = safeParse(likesOnPostRequestSchema, input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts increment value at MAX_INCREMENT_VALUE', () => {
+      // Arrange
+      const input = { increment: MAX_INCREMENT_VALUE };
+
+      // Act
+      const result = safeParse(likesOnPostRequestSchema, input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects increment value of 0', () => {
+      // Arrange
+      const input = { increment: 0 };
+
+      // Act
+      const result = safeParse(likesOnPostRequestSchema, input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues[0].message).toBe('Increment must be at least 1');
+      }
+    });
+
+    it('rejects negative increment value', () => {
+      // Arrange
+      const input = { increment: -1 };
+
+      // Act
+      const result = safeParse(likesOnPostRequestSchema, input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues[0].message).toBe('Increment must be at least 1');
+      }
+    });
+
+    it('rejects increment value exceeding MAX_INCREMENT_VALUE', () => {
+      // Arrange
+      const input = { increment: MAX_INCREMENT_VALUE + 1 };
+
+      // Act
+      const result = safeParse(likesOnPostRequestSchema, input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.issues[0].message).toBe(`Increment must be at most ${MAX_INCREMENT_VALUE}`);
+      }
+    });
+
+    it('rejects non-integer increment value', () => {
+      // Arrange
+      const input = { increment: 1.5 };
+
+      // Act
+      const result = safeParse(likesOnPostRequestSchema, input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/app/src/features/likes/api/likesApiValidationSchema.ts
+++ b/app/src/features/likes/api/likesApiValidationSchema.ts
@@ -1,4 +1,6 @@
-import { type InferOutput, integer, minValue, number, object, pipe, string } from 'valibot';
+import { type InferOutput, integer, maxValue, minValue, number, object, pipe, string } from 'valibot';
+
+export const MAX_INCREMENT_VALUE = 100;
 
 export const likesOnGetResponseSchema = object({
   id: pipe(string()),
@@ -6,7 +8,12 @@ export const likesOnGetResponseSchema = object({
 });
 
 export const likesOnPostRequestSchema = object({
-  increment: pipe(number(), integer(), minValue(1, 'Increment must be at least 1')),
+  increment: pipe(
+    number(),
+    integer(),
+    minValue(1, 'Increment must be at least 1'),
+    maxValue(MAX_INCREMENT_VALUE, `Increment must be at most ${MAX_INCREMENT_VALUE}`),
+  ),
 });
 
 export const likesOnPostResponseSchema = object({


### PR DESCRIPTION
Prevent malicious users from adding a large number of likes in a single request by setting an upper limit on increment.

- Add `maxValue(100)` to Valibot schema
- Export `MAX_INCREMENT_VALUE` constant for reuse