### PR TITLE
fix: use IP + entryId combination for rate limiting

### DIFF
--- a/app/src/features/likes/utils/getClientIp.ts
+++ b/app/src/features/likes/utils/getClientIp.ts
@@ -1,0 +1,9 @@
+const DEFAULT_CLIENT_IP = 'unknown';
+
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get('CF-Connecting-IP') ??
+    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ??
+    DEFAULT_CLIENT_IP
+  );
+}

--- a/app/src/features/likes/utils/rateLimiter.test.ts
+++ b/app/src/features/likes/utils/rateLimiter.test.ts
@@ -10,11 +10,15 @@ describe('checkRateLimit', () => {
     };
 
     // Act
-    const response = await checkRateLimit({ entryId: 'some-entry-id', rateLimiter: mockRateLimiter });
+    const response = await checkRateLimit({
+      clientIp: '192.168.1.1',
+      entryId: 'some-entry-id',
+      rateLimiter: mockRateLimiter,
+    });
 
     // Assert
     expect(response).toBe(false);
-    expect(mockRateLimiter.limit).toHaveBeenCalledWith({ key: 'some-entry-id' });
+    expect(mockRateLimiter.limit).toHaveBeenCalledWith({ key: '192.168.1.1:some-entry-id' });
   });
 
   test('should return true when rate limit is exceeded', async () => {
@@ -24,12 +28,16 @@ describe('checkRateLimit', () => {
     };
 
     // Act
-    const response = await checkRateLimit({ entryId: 'some-entry-id', rateLimiter: mockRateLimiter });
+    const response = await checkRateLimit({
+      clientIp: '192.168.1.1',
+      entryId: 'some-entry-id',
+      rateLimiter: mockRateLimiter,
+    });
 
     // Assert
     expect(response).not.toBeNull();
     expect(response).toBe(true);
-    expect(mockRateLimiter.limit).toHaveBeenCalledWith({ key: 'some-entry-id' });
+    expect(mockRateLimiter.limit).toHaveBeenCalledWith({ key: '192.168.1.1:some-entry-id' });
   });
 
   test('should return false when rate limiter throws error (fail open)', async () => {
@@ -40,7 +48,11 @@ describe('checkRateLimit', () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     // Act
-    const response = await checkRateLimit({ entryId: 'some-entry-id', rateLimiter: mockRateLimiter });
+    const response = await checkRateLimit({
+      clientIp: '192.168.1.1',
+      entryId: 'some-entry-id',
+      rateLimiter: mockRateLimiter,
+    });
 
     // Assert
     expect(response).toBe(false);

--- a/app/src/features/likes/utils/rateLimiter.test.ts
+++ b/app/src/features/likes/utils/rateLimiter.test.ts
@@ -18,7 +18,9 @@ describe('checkRateLimit', () => {
 
     // Assert
     expect(response).toBe(false);
-    expect(mockRateLimiter.limit).toHaveBeenCalledWith({ key: '192.168.1.1:some-entry-id' });
+    expect(mockRateLimiter.limit).toHaveBeenCalledWith({
+      key: JSON.stringify({ clientIp: '192.168.1.1', entryId: 'some-entry-id' }),
+    });
   });
 
   test('should return true when rate limit is exceeded', async () => {
@@ -37,7 +39,9 @@ describe('checkRateLimit', () => {
     // Assert
     expect(response).not.toBeNull();
     expect(response).toBe(true);
-    expect(mockRateLimiter.limit).toHaveBeenCalledWith({ key: '192.168.1.1:some-entry-id' });
+    expect(mockRateLimiter.limit).toHaveBeenCalledWith({
+      key: JSON.stringify({ clientIp: '192.168.1.1', entryId: 'some-entry-id' }),
+    });
   });
 
   test('should return false when rate limiter throws error (fail open)', async () => {

--- a/app/src/features/likes/utils/rateLimiter.ts
+++ b/app/src/features/likes/utils/rateLimiter.ts
@@ -1,6 +1,7 @@
 import type { RateLimit } from '@cloudflare/workers-types/experimental';
 
 type Params = {
+  clientIp: string;
   entryId: string;
   rateLimiter: RateLimit;
 };
@@ -9,12 +10,16 @@ type Params = {
  * Checks the rate limit and returns true if the limit is exceeded.
  * Returns false if the limit has not been exceeded.
  *
- * @param params - The parameters including rate limiter instance and entry ID
+ * Uses a combination of client IP and entry ID as the rate limit key
+ * to prevent abuse while allowing different users to like the same entry.
+ *
+ * @param params - The parameters including rate limiter instance, client IP, and entry ID
  * @returns true if rate limit is exceeded, false otherwise
  */
-export async function checkRateLimit({ entryId, rateLimiter }: Params): Promise<boolean> {
+export async function checkRateLimit({ clientIp, entryId, rateLimiter }: Params): Promise<boolean> {
   try {
-    const { success } = await rateLimiter.limit({ key: entryId });
+    const rateLimitKey = `${clientIp}:${entryId}`;
+    const { success } = await rateLimiter.limit({ key: rateLimitKey });
     return !success;
   } catch (error) {
     console.error('Rate limit check failed:', error);

--- a/app/src/features/likes/utils/rateLimiter.ts
+++ b/app/src/features/likes/utils/rateLimiter.ts
@@ -18,7 +18,7 @@ type Params = {
  */
 export async function checkRateLimit({ clientIp, entryId, rateLimiter }: Params): Promise<boolean> {
   try {
-    const rateLimitKey = `${clientIp}:${entryId}`;
+    const rateLimitKey = JSON.stringify({ clientIp, entryId });
     const { success } = await rateLimiter.limit({ key: rateLimitKey });
     return !success;
   } catch (error) {

--- a/app/src/pages/api/likes/[id].ts
+++ b/app/src/pages/api/likes/[id].ts
@@ -27,7 +27,7 @@ function createNormalizedCacheKey(request: Request): string {
   return url.toString();
 }
 
-function getClientIp(request: Request): string {
+export function getClientIp(request: Request): string {
   return (
     request.headers.get('CF-Connecting-IP') ??
     request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ??

--- a/app/src/pages/api/likes/[id].ts
+++ b/app/src/pages/api/likes/[id].ts
@@ -9,12 +9,12 @@ import { getLikeCounts, incrementLikeCounts } from '../../../features/likes/api/
 import { likesOnPostRequestSchema } from '../../../features/likes/api/likesApiValidationSchema';
 import { entryExists, type GetEntryFn } from '../../../features/likes/utils/entryExistence';
 import { isValidEntryIdFormat } from '../../../features/likes/utils/entryValidator';
+import { getClientIp } from '../../../features/likes/utils/getClientIp';
 import { checkRateLimit } from '../../../features/likes/utils/rateLimiter';
 
 export const prerender = false;
 
 const COOLDOWN_PERIOD_SECONDS = 30;
-const DEFAULT_CLIENT_IP = 'unknown';
 
 function getCache({ locals }: Pick<APIContext, 'locals'>): Cache | null {
   const cache = locals.runtime?.caches?.default ?? null;
@@ -25,14 +25,6 @@ function createNormalizedCacheKey(request: Request): string {
   const url = new URL(request.url);
   url.search = '';
   return url.toString();
-}
-
-export function getClientIp(request: Request): string {
-  return (
-    request.headers.get('CF-Connecting-IP') ??
-    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ??
-    DEFAULT_CLIENT_IP
-  );
 }
 
 export async function GET({ locals, params, request }: APIContext): Promise<Response> {

--- a/app/src/pages/api/likes/[id].ts
+++ b/app/src/pages/api/likes/[id].ts
@@ -29,8 +29,8 @@ function createNormalizedCacheKey(request: Request): string {
 
 function getClientIp(request: Request): string {
   return (
-    request.headers.get('cf-connecting-ip') ??
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('CF-Connecting-IP') ??
+    request.headers.get('X-Forwarded-For')?.split(',')[0]?.trim() ??
     DEFAULT_CLIENT_IP
   );
 }

--- a/app/src/pages/api/likes/getClientIp.test.ts
+++ b/app/src/pages/api/likes/getClientIp.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'vitest';
+
+import { getClientIp } from './[id]';
+
+describe('getClientIp', () => {
+  test('should return CF-Connecting-IP header when present', () => {
+    // Arrange
+    const request = new Request('https://example.com', {
+      headers: {
+        'CF-Connecting-IP': '203.0.113.1',
+      },
+    });
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('203.0.113.1');
+  });
+
+  test('should return first IP from X-Forwarded-For when CF-Connecting-IP is absent', () => {
+    // Arrange
+    const request = new Request('https://example.com', {
+      headers: {
+        'X-Forwarded-For': '192.168.1.1, 10.0.0.1, 172.16.0.1',
+      },
+    });
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('192.168.1.1');
+  });
+
+  test('should return single IP from X-Forwarded-For correctly', () => {
+    // Arrange
+    const request = new Request('https://example.com', {
+      headers: {
+        'X-Forwarded-For': '192.168.1.1',
+      },
+    });
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('192.168.1.1');
+  });
+
+  test('should trim whitespace from X-Forwarded-For IP', () => {
+    // Arrange
+    const request = new Request('https://example.com', {
+      headers: {
+        'X-Forwarded-For': '  192.168.1.1  , 10.0.0.1',
+      },
+    });
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('192.168.1.1');
+  });
+
+  test('should return default "unknown" when no IP headers are present', () => {
+    // Arrange
+    const request = new Request('https://example.com');
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('unknown');
+  });
+
+  test('should prefer CF-Connecting-IP over X-Forwarded-For', () => {
+    // Arrange
+    const request = new Request('https://example.com', {
+      headers: {
+        'CF-Connecting-IP': '203.0.113.1',
+        'X-Forwarded-For': '192.168.1.1',
+      },
+    });
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('203.0.113.1');
+  });
+
+  test('should handle IPv6 address from CF-Connecting-IP', () => {
+    // Arrange
+    const request = new Request('https://example.com', {
+      headers: {
+        'CF-Connecting-IP': '2001:db8::1',
+      },
+    });
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('2001:db8::1');
+  });
+
+  test('should handle IPv6 address from X-Forwarded-For', () => {
+    // Arrange
+    const request = new Request('https://example.com', {
+      headers: {
+        'X-Forwarded-For': '2001:db8::1, 2001:db8::2',
+      },
+    });
+
+    // Act
+    const result = getClientIp(request);
+
+    // Assert
+    expect(result).toBe('2001:db8::1');
+  });
+});

--- a/app/src/pages/api/likes/getClientIp.test.ts
+++ b/app/src/pages/api/likes/getClientIp.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { getClientIp } from './[id]';
+import { getClientIp } from '../../../features/likes/utils/getClientIp';
 
 describe('getClientIp', () => {
   test('should return CF-Connecting-IP header when present', () => {


### PR DESCRIPTION
Change rate limit key from entryId alone to client IP + entryId combination. This allows different users to like the same entry while preventing abuse from a single source.

- Add clientIp parameter to rateLimiter.ts
- Get IP from `CF-Connecting-IP` header with `X-Forwarded-For` fallback
- Update tests accordingly