### PR TITLE
fix: add log message before silent exit in gh-setup hook

### DIFF
--- a/.claude/hooks/gh-setup.sh
+++ b/.claude/hooks/gh-setup.sh
@@ -11,6 +11,7 @@ log() {
 }
 
 if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
+    log "Not running in remote environment, skipping gh setup"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

When CLAUDE_CODE_REMOTE is not true, the script was exiting silently without any output, causing "Failed with non-blocking status code" error in Claude Code's hook system.