### PR TITLE
feat(tracking): add GA event tracking via GTM dataLayer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,29 @@ jobs:
 
       - name: Run testing
         run: npm run test
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    needs: [lint, check]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          cache: 'npm'
+          node-version: 24
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: app
+
+      - name: Run E2E tests
+        run: npx playwright test
+        working-directory: app
+        env:
+          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}

--- a/app/e2e/tracking.spec.ts
+++ b/app/e2e/tracking.spec.ts
@@ -1,0 +1,131 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// Inject window.dataLayer before any page script runs so that
+// pushEvent() calls always land in the array, regardless of the
+// /api/optout response in the dev environment.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.dataLayer = [];
+  });
+});
+
+function getDataLayer(page: Page): Promise<Array<Record<string, unknown>>> {
+  return page.evaluate(() => (window as Window & { dataLayer?: Record<string, unknown>[] }).dataLayer ?? []);
+}
+
+function filterEvents(dataLayer: Array<Record<string, unknown>>, eventName: string): Array<Record<string, unknown>> {
+  return dataLayer.filter((entry) => entry.event == eventName);
+}
+
+const ARTICLE_PATH = '/entries/blog-renewal-2025';
+
+test.describe('GA event tracking', () => {
+  test('scroll_depth does not fire on initial page load', async ({ page }) => {
+    // Given
+    await page.goto(ARTICLE_PATH);
+
+    // When
+    await page.waitForTimeout(500);
+
+    // Then
+    const dataLayer = await getDataLayer(page);
+    const scrollEvents = filterEvents(dataLayer, 'scroll_depth');
+    expect(scrollEvents).toHaveLength(0);
+  });
+
+  test('like_click pushes event to dataLayer', async ({ page }) => {
+    // Given
+    await page.goto(ARTICLE_PATH);
+    const likeButton = page.locator('button[aria-label]').filter({ hasText: '👏' });
+    await likeButton.scrollIntoViewIfNeeded();
+    // Wait for Astro island hydration (client:visible)
+    const likeIsland = page.locator('astro-island[component-export="LikeButton"]');
+    await expect(likeIsland).not.toHaveAttribute('ssr', '', { timeout: 10_000 });
+
+    // When
+    await likeButton.click();
+
+    // Then
+    const dataLayer = await getDataLayer(page);
+    const likeEvents = filterEvents(dataLayer, 'like_click');
+    expect(likeEvents.length).toBeGreaterThanOrEqual(1);
+
+    const likeEvent = likeEvents[0]!;
+    expect(likeEvent).toMatchObject({
+      event: 'like_click',
+      entry_id: 'blog-renewal-2025',
+    });
+    expect(likeEvent.entry_title).toBeTruthy();
+  });
+
+  test('share_click pushes event to dataLayer', async ({ page }) => {
+    // Given
+    await page.goto(ARTICLE_PATH);
+    const xShareLink = page.locator('a[data-share-platform="x"]');
+    await xShareLink.waitFor({ state: 'visible' });
+    await xShareLink.evaluate((el) => {
+      el.addEventListener('click', (e) => e.preventDefault(), { once: true });
+    });
+
+    // When
+    await xShareLink.click();
+
+    // Then
+    const dataLayer = await getDataLayer(page);
+    const shareEvents = filterEvents(dataLayer, 'share_click');
+    expect(shareEvents.length).toBeGreaterThanOrEqual(1);
+
+    const shareEvent = shareEvents[0]!;
+    expect(shareEvent).toMatchObject({
+      event: 'share_click',
+      share_platform: 'x',
+      entry_id: 'blog-renewal-2025',
+    });
+    expect(shareEvent.entry_title).toBeTruthy();
+  });
+
+  test('scroll_depth pushes events for each threshold', async ({ page }) => {
+    // Given
+    await page.goto(ARTICLE_PATH);
+    await page.evaluate(() => window.scrollBy(0, 1));
+    await page.waitForTimeout(200);
+
+    // When
+    for (const pct of [30, 55, 80, 100]) {
+      await page.evaluate((p) => {
+        const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+        window.scrollTo(0, (scrollHeight * p) / 100);
+      }, pct);
+      await page.waitForTimeout(300);
+    }
+
+    // Then
+    const dataLayer = await getDataLayer(page);
+    const scrollEvents = filterEvents(dataLayer, 'scroll_depth');
+    const percentages = scrollEvents.map((e) => e.scroll_percentage);
+
+    expect(percentages).toContain(25);
+    expect(percentages).toContain(50);
+    expect(percentages).toContain(75);
+    expect(percentages).toContain(90);
+  });
+
+  test('rss_click pushes event to dataLayer', async ({ page }) => {
+    // Given
+    await page.goto(ARTICLE_PATH);
+    const rssLink = page.locator('#rss-link');
+    await rssLink.waitFor({ state: 'visible' });
+    await rssLink.evaluate((el) => {
+      el.addEventListener('click', (e) => e.preventDefault(), { once: true });
+    });
+
+    // When
+    await rssLink.click();
+
+    // Then
+    const dataLayer = await getDataLayer(page);
+    const rssEvents = filterEvents(dataLayer, 'rss_click');
+    expect(rssEvents.length).toBeGreaterThanOrEqual(1);
+    expect(rssEvents[0]).toMatchObject({ event: 'rss_click' });
+  });
+});

--- a/app/package.json
+++ b/app/package.json
@@ -22,6 +22,7 @@
     "lint:style": "stylelint '**/*.css'",
     "lint:script": "eslint '**/*.{ts,tsx}'",
     "lint:markup": "markuplint '**/*.astro'",
+    "e2e": "playwright test",
     "storybook": "storybook dev -p 6006"
   },
   "dependencies": {

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  ...(process.env.CI ? { workers: 1 } : {}),
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:4321',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:4321',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/app/src/data/tracking/dataLayer.ts
+++ b/app/src/data/tracking/dataLayer.ts
@@ -6,6 +6,16 @@ declare global {
   }
 }
 
+export type TrackingEvent = {
+  event: string;
+  [key: string]: unknown;
+};
+
+export const pushEvent = (eventData: TrackingEvent): void => {
+  const win = getBrowsingContextWindowProxy();
+  win?.dataLayer?.push(eventData);
+};
+
 export const initialDatalayer = (): void => {
   const win = getBrowsingContextWindowProxy();
   if (win === null) {

--- a/app/src/data/tracking/dataLayer.ts
+++ b/app/src/data/tracking/dataLayer.ts
@@ -11,9 +11,17 @@ export type TrackingEvent = {
   [key: string]: unknown;
 };
 
+// Reset properties not included in the current event to prevent
+// GTM dataLayer state from leaking between different event types.
+const defaultProperties: Record<string, undefined> = {
+  share_platform: undefined,
+  entry_id: undefined,
+  entry_title: undefined,
+};
+
 export const pushEvent = (eventData: TrackingEvent): void => {
   const win = getBrowsingContextWindowProxy();
-  win?.dataLayer?.push(eventData);
+  win?.dataLayer?.push({ ...defaultProperties, ...eventData });
 };
 
 export const initialDatalayer = (): void => {

--- a/app/src/features/entry/components/ScrollDepthTracker.astro
+++ b/app/src/features/entry/components/ScrollDepthTracker.astro
@@ -1,0 +1,58 @@
+---
+export interface Props {
+  entryId: string;
+  entryTitle: string;
+}
+
+const { entryId, entryTitle } = Astro.props;
+const thresholds = [25, 50, 75, 90];
+---
+
+<div id="scroll-depth-tracker" data-entry-id={entryId} data-entry-title={entryTitle}>
+  {thresholds.map((pct) => <div data-scroll-marker={pct} style={`position:absolute;top:${pct}%;width:0;height:0;`} />)}
+</div>
+
+<script>
+  import { pushEvent } from '../../../data/tracking/dataLayer';
+
+  const tracker = document.getElementById('scroll-depth-tracker');
+  if (tracker != null) {
+    const entryId = tracker.dataset.entryId ?? '';
+    const entryTitle = tracker.dataset.entryTitle ?? '';
+    const fired = new Set<number>();
+
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) {
+          continue;
+        }
+        const pct = Number((entry.target as HTMLElement).dataset.scrollMarker);
+        if (fired.has(pct)) {
+          continue;
+        }
+        fired.add(pct);
+        pushEvent({
+          event: 'scroll_depth',
+          scroll_percentage: pct,
+          entry_id: entryId,
+          entry_title: entryTitle,
+        });
+        observer.unobserve(entry.target);
+      }
+    });
+
+    const markers = tracker.querySelectorAll<HTMLElement>('[data-scroll-marker]');
+
+    // Start observing only after the user scrolls to avoid
+    // firing events for content already visible on page load.
+    window.addEventListener(
+      'scroll',
+      () => {
+        for (const marker of Array.from(markers)) {
+          observer.observe(marker);
+        }
+      },
+      { once: true },
+    );
+  }
+</script>

--- a/app/src/features/entry/components/Share.astro
+++ b/app/src/features/entry/components/Share.astro
@@ -3,11 +3,12 @@ import BlueskyIcon from '../../../assets/bluesky.svg';
 import XIcon from '../../../assets/x.svg';
 
 export interface Props {
+  entryId: string;
   title: string;
   url: string;
 }
 
-const { title, url } = Astro.props;
+const { entryId, title, url } = Astro.props;
 
 const blueskyParams = new URLSearchParams({ text: `${title} ${url}` });
 const blueskyShareUrl = `https://bsky.app/intent/compose?${blueskyParams}`;
@@ -68,8 +69,17 @@ const xShareUrl = `https://twitter.com/intent/tweet?${xParams}`;
   }
 </style>
 
-<div class="Container">
-  <a href={xShareUrl} target="_blank" rel="noopener noreferrer" class="Link X" aria-label={`Xで${title}をシェアする`}>
+<div class="Container" id="share-container">
+  <a
+    href={xShareUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="Link X"
+    aria-label={`Xで${title}をシェアする`}
+    data-share-platform="x"
+    data-entry-id={entryId}
+    data-entry-title={title}
+  >
     <span class="Icon">
       <XIcon width="24" height="24" />
     </span>
@@ -80,9 +90,30 @@ const xShareUrl = `https://twitter.com/intent/tweet?${xParams}`;
     rel="noopener noreferrer"
     class="Link Bluesky"
     aria-label={`Blueskyで${title}をシェアする`}
+    data-share-platform="bluesky"
+    data-entry-id={entryId}
+    data-entry-title={title}
   >
     <span class="Icon">
       <BlueskyIcon width="24" height="24" />
     </span>
   </a>
 </div>
+
+<script>
+  import { pushEvent } from '../../../data/tracking/dataLayer';
+
+  const container = document.getElementById('share-container');
+  container?.addEventListener('click', (e) => {
+    const link = (e.target as Element).closest<HTMLAnchorElement>('a[data-share-platform]');
+    if (link == null) {
+      return;
+    }
+    pushEvent({
+      event: 'share_click',
+      share_platform: link.dataset.sharePlatform ?? '',
+      entry_id: link.dataset.entryId ?? '',
+      entry_title: link.dataset.entryTitle ?? '',
+    });
+  });
+</script>

--- a/app/src/features/likes/components/LikeButton/LikeButton.tsx
+++ b/app/src/features/likes/components/LikeButton/LikeButton.tsx
@@ -3,23 +3,26 @@
 import clsx from 'clsx';
 import { useCallback, useState } from 'react';
 
+import { pushEvent } from '../../../../data/tracking/dataLayer';
 import { useLikes } from '../../hooks/useLikes';
 import { LikeCountsSkeleton } from '../LikeCountsSkeleton';
 import styles from './LikeButton.module.css';
 
 type Props = {
   entryId: string;
+  entryTitle: string;
   likeLabel: string;
   onClick?: () => void;
 };
 
-export function LikeButton({ entryId, likeLabel, onClick }: Props): React.JSX.Element {
+export function LikeButton({ entryId, entryTitle, likeLabel, onClick }: Props): React.JSX.Element {
   const [clapping, setClapping] = useState(false);
 
   const { counts, handleLikes, isLoading } = useLikes({ entryId });
 
   const handleClick = useCallback(() => {
     handleLikes();
+    pushEvent({ event: 'like_click', entry_id: entryId, entry_title: entryTitle });
 
     setClapping(false);
     requestAnimationFrame(() => {
@@ -27,7 +30,7 @@ export function LikeButton({ entryId, likeLabel, onClick }: Props): React.JSX.El
     });
 
     onClick?.();
-  }, [handleLikes, onClick]);
+  }, [handleLikes, entryId, entryTitle, onClick]);
 
   const handleAnimationEnd = useCallback(() => {
     setClapping(false);

--- a/app/src/layouts/GlobalFooter.astro
+++ b/app/src/layouts/GlobalFooter.astro
@@ -56,7 +56,7 @@ import RssIcon from '../assets/rss.svg';
 </style>
 
 <footer class="Footer">
-  <a class="RssLink" href={`/${pathList.feed}`}>
+  <a class="RssLink" id="rss-link" href={`/${pathList.feed}`}>
     <RssIcon />
     <span>
       {retrieveTranslation('navigation.feed')}
@@ -72,3 +72,12 @@ import RssIcon from '../assets/rss.svg';
     </p>
   </div>
 </footer>
+
+<script>
+  import { pushEvent } from '../data/tracking/dataLayer';
+
+  const rssLink = document.getElementById('rss-link');
+  rssLink?.addEventListener('click', () => {
+    pushEvent({ event: 'rss_click' });
+  });
+</script>

--- a/app/src/pages/entries/[id].astro
+++ b/app/src/pages/entries/[id].astro
@@ -9,6 +9,7 @@ import { OG_IMAGE_PATH } from '../../../constants/siteData';
 import { retrieveTranslation } from '../../../locales/i18n';
 import { createBlogPostingStructuredData } from '../../data/structured_data/blogPostingStructuredData';
 import PublicationMetadata from '../../features/entry/components/PublicationMetadata.astro';
+import ScrollDepthTracker from '../../features/entry/components/ScrollDepthTracker.astro';
 import Share from '../../features/entry/components/Share.astro';
 import Taxonomy from '../../features/entry/components/Taxonomy.astro';
 import { formatIsoString } from '../../features/entry/date';
@@ -68,6 +69,7 @@ const structuredData = JSON.stringify(
   }
 
   .Contents {
+    position: relative;
     margin-top: var(--space-component-4);
   }
 
@@ -120,6 +122,7 @@ const structuredData = JSON.stringify(
         </header>
         <div class="Contents">
           <Content />
+          <ScrollDepthTracker entryId={id} entryTitle={entryTitle} />
         </div>
         <footer>
           {tags.length > 0 && <Taxonomy tags={tags} />}

--- a/app/src/pages/entries/[id].astro
+++ b/app/src/pages/entries/[id].astro
@@ -137,7 +137,7 @@ const structuredData = JSON.stringify(
               )
             }
             <div class="Share">
-              <Share title={entryTitle} url={url} />
+              <Share entryId={id} title={entryTitle} url={url} />
             </div>
           </div>
         </aside>

--- a/app/src/pages/entries/[id].astro
+++ b/app/src/pages/entries/[id].astro
@@ -128,7 +128,12 @@ const structuredData = JSON.stringify(
           <div class="Actions">
             {
               isLikeEnabled && (
-                <LikeButton client:visible entryId={id} likeLabel={retrieveTranslation('entry.action.like')} />
+                <LikeButton
+                  client:visible
+                  entryId={id}
+                  entryTitle={entryTitle}
+                  likeLabel={retrieveTranslation('entry.action.like')}
+                />
               )
             }
             <div class="Share">

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -8,6 +8,7 @@
     ".astro/types.d.ts",
     ".storybook/**/*",
     "constants/**/*",
+    "e2e/**/*",
     "locales/**/*",
     "src/**/*",
     "*.config.*",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,7 @@ export default defineConfig([
             '**/__mocks__/**/*.ts',
             '**/__tests__/**/*.ts',
             '**/.storybook/**/*.ts',
+            '**/e2e/**/*.ts',
             '**/tools/**/*.ts',
           ],
         },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:style": "turbo run lint:style",
     "lint:script": "turbo run lint:script",
     "lint:markup": "turbo run lint:markup",
+    "e2e": "turbo run e2e",
     "storybook": "turbo run storybook"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,10 @@
       "outputs": ["playwright-report/**", "test-results/**"],
       "inputs": ["app/**/*.test.ts", "app/**/*.test.tsx", "vitest.config.ts"]
     },
+    "e2e": {
+      "dependsOn": ["build"],
+      "cache": false
+    },
     "format": {
       "cache": false
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       '**/.{idea,git,cache,output,temp}/**',
       '**/cypress/**',
       '**/dist/**',
+      '**/e2e/**',
       '**/node_modules/**',
       '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
     ],


### PR DESCRIPTION
## Summary

- fixed https://github.com/kubosho/blog.kubosho.com/issues/410

Implemented the pushEvent utility to track user interactions via GTM dataLayer, including button clicks (like, share, RSS) and scroll depth milestones (25-90%) using Intersection Observer.

## Changes

- Add `pushEvent` utility to push custom events to GTM dataLayer
- Track `like_click` events when the like button is clicked
- Track `share_click` events when X or Bluesky share buttons are clicked
- Track `scroll_depth` events at 25/50/75/90% thresholds using Intersection Observer (only after user scrolls)
- Track `rss_click` events when the RSS feed link is clicked

## Test plan

- [x] `like_click`: Click the like button and verify `like_click` event with `entry_id` and `entry_title` is pushed to `window.dataLayer`
- [x] `share_click`: Click the X share button and verify `share_click` event with `share_platform`, `entry_id`, and `entry_title` is pushed
- [x] `scroll_depth`: Scroll through an article and verify all four thresholds (25/50/75/90) fire; verify no events fire on page load without scrolling
- [x] `rss_click`: Click the RSS link in the footer and verify `rss_click` event is pushed
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint:script`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)