### PR TITLE
feat: allow configuring articles directory via env var

### DIFF
--- a/app/src/content.config.ts
+++ b/app/src/content.config.ts
@@ -2,8 +2,10 @@ import { glob } from 'astro/loaders';
 import { z } from 'astro/zod';
 import { defineCollection } from 'astro:content';
 
+const ARTICLES_DIR = process.env.ARTICLES_DIR ?? '../articles';
+
 const entries = defineCollection({
-  loader: glob({ pattern: '**/*.{md,mdx}', base: '../articles' }),
+  loader: glob({ pattern: '**/*.{md,mdx}', base: ARTICLES_DIR }),
   schema: z.object({
     title: z.string(),
     excerpt: z.string().optional(),

--- a/turbo.json
+++ b/turbo.json
@@ -7,19 +7,23 @@
     },
     "build": {
       "dependsOn": ["^build"],
+      "env": ["ARTICLES_DIR"],
       "outputs": [".astro/**", "dist/**"],
       "cache": true
     },
     "build:prd": {
       "dependsOn": ["^build"],
+      "env": ["ARTICLES_DIR"],
       "outputs": [".astro/**", "dist/**"],
       "cache": true
     },
     "dev": {
+      "env": ["ARTICLES_DIR"],
       "cache": false,
       "persistent": true
     },
     "dev:prd": {
+      "env": ["ARTICLES_DIR"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Summary

The articles directory path in `content.config.ts` was hardcoded to `../articles`. This change allows overriding it via the `ARTICLES_DIR` environment variable, making it easy to load articles from a different directory during local development. When the variable is not set, it falls back to the default `../articles`.

## Usage

```bash
# Specify directly on the command line
ARTICLES_DIR=../my-other-articles npm run dev

# Or add to .dev.vars
ARTICLES_DIR=../my-other-articles
```

## Test plan

- [x] Run `npm run dev` without the env var — articles load from the default `../articles`
- [x] Run `ARTICLES_DIR=../articles npm run dev` — articles load normally
- [x] Specify a non-existent path — empty article list

🤖 Generated with [Claude Code](https://claude.com/claude-code)