### PR TITLE
feat: add Cache-Control header to likes GET API response

### DIFF
--- a/app/src/pages/api/likes/[id].ts
+++ b/app/src/pages/api/likes/[id].ts
@@ -15,6 +15,7 @@ import { checkRateLimit } from '../../../features/likes/utils/rateLimiter';
 export const prerender = false;
 
 const COOLDOWN_PERIOD_SECONDS = 30;
+const EDGE_CACHE_TTL_SECONDS = 60;
 
 function getCache({ locals }: Pick<APIContext, 'locals'>): Cache | null {
   const cache = locals.runtime?.caches?.default ?? null;
@@ -69,6 +70,7 @@ export async function GET({ locals, params, request }: APIContext): Promise<Resp
         status: 200,
         headers: {
           'Content-Type': 'application/json',
+          'Cache-Control': `public, max-age=0, s-maxage=${EDGE_CACHE_TTL_SECONDS}`,
         },
       },
     );


### PR DESCRIPTION
## Summary

The likes GET API (`/api/likes/[id]`) response had no `Cache-Control` header, leaving browser cache behavior and edge cache TTL implicit. Adding an explicit header makes caching behavior predictable.

### Changes

- Set `Cache-Control: public, max-age=0, s-maxage=60` on GET success responses
- Add `EDGE_CACHE_TTL_SECONDS` constant

### Directive intent

| Directive | Value | Purpose |
|-----------|-------|---------|
| `public` | - | Like counts are shared across all users, so shared caches may store the response |
| `max-age` | `0` | Browsers always fetch fresh data from the server |
| `s-maxage` | `60` | Edge cache TTL (explicit invalidation via `cache.delete()` on POST) |

### What was NOT changed

- **POST responses**: Not cached by default per HTTP spec
- **Error responses**: Never passed to `cache.put()`, so no header needed

### References

- [Cloudflare Cache-Control directives](https://developers.cloudflare.com/cache/concepts/cache-control/)
- [Cloudflare Workers Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache/)

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] `curl -v` confirms `Cache-Control` header in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)