### PR TITLE
test: add unit tests for addWbr utility

### DIFF
--- a/app/src/utils/addWbr.test.ts
+++ b/app/src/utils/addWbr.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+
+import { addWbr } from './addWbr';
+
+describe('addWbr', () => {
+  test('inserts <wbr /> after a Japanese comma', () => {
+    // Arrange
+    const input = 'これは、テストです';
+
+    // Act
+    const result = addWbr(input);
+
+    // Assert
+    expect(result).toEqual('これは、<wbr />テストです');
+  });
+
+  test('returns the string unchanged when no Japanese comma is present', () => {
+    // Arrange
+    const input = '読点なし';
+
+    // Act
+    const result = addWbr(input);
+
+    // Assert
+    expect(result).toEqual('読点なし');
+  });
+
+  test('inserts <wbr /> after every Japanese comma', () => {
+    // Arrange
+    const input = '一つ、二つ、三つ';
+
+    // Act
+    const result = addWbr(input);
+
+    // Assert
+    expect(result).toEqual('一つ、<wbr />二つ、<wbr />三つ');
+  });
+
+  test('returns an empty string as-is', () => {
+    // Arrange
+    const input = '';
+
+    // Act
+    const result = addWbr(input);
+
+    // Assert
+    expect(result).toEqual('');
+  });
+});


### PR DESCRIPTION
## Summary

`addWbr` ユーティリティにテストが存在しなかったため、振る舞いを検証する単体テストを追加した。純粋関数なので入力と出力のみでテストできる。

## Changes

- addWbr の単体テストを追加（読点後の `<wbr />` 挿入、読点なし文字列のパススルー、複数読点、空文字列の4ケース）

## Test plan

- [x] `npx vitest run app/src/utils/addWbr.test.ts` で4件すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)