### PR TITLE
test: add structured data generation tests

### DIFF
--- a/app/src/data/structured_data/blogPostingStructuredData.test.ts
+++ b/app/src/data/structured_data/blogPostingStructuredData.test.ts
@@ -1,0 +1,36 @@
+vi.mock('../../../locales/i18n', () => ({
+  retrieveTranslation: vi.fn(() => 'Test Author'),
+}));
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createBlogPostingStructuredData } from './blogPostingStructuredData';
+
+describe('createBlogPostingStructuredData', () => {
+  it('should return a valid BlogPosting JSON-LD structure', () => {
+    // Arrange
+    const params = {
+      title: 'Test Title',
+      content: 'Test article body content',
+      publishedDateString: '2024-01-15',
+      revisedDateString: '2024-02-20',
+    };
+
+    // Act
+    const result = createBlogPostingStructuredData(params);
+
+    // Assert
+    expect(result).toEqual({
+      '@context': 'http://schema.org',
+      '@type': 'BlogPosting',
+      articleBody: 'Test article body content',
+      author: {
+        '@type': 'Person',
+        name: 'Test Author',
+      },
+      dateModified: '2024-02-20',
+      datePublished: '2024-01-15',
+      headline: 'Test Title',
+    });
+  });
+});

--- a/app/src/data/structured_data/homeStructuredData.test.ts
+++ b/app/src/data/structured_data/homeStructuredData.test.ts
@@ -1,0 +1,24 @@
+vi.mock('../../../locales/i18n', () => ({
+  retrieveTranslation: vi.fn(() => 'Test Site Name'),
+}));
+
+vi.stubEnv('SITE', 'https://example.com');
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createHomeStructuredData } from './homeStructuredData';
+
+describe('createHomeStructuredData', () => {
+  it('should return a valid WebSite JSON-LD structure', () => {
+    // Act
+    const result = createHomeStructuredData();
+
+    // Assert
+    expect(result).toEqual({
+      '@context': 'http://schema.org',
+      '@type': 'WebSite',
+      name: 'Test Site Name',
+      url: 'https://example.com',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

構造化データ生成関数にテストがなく、JSON-LDの出力構造が変更されてもCIで検知できない状態だった。BlogPosting（記事ページ）とWebSite（トップページ）の両方にテストを追加し、schema.orgマークアップの回帰を防止する。

## Changes

- BlogPosting構造化データのJSON-LD出力を検証するテストを追加
- WebSite構造化データのJSON-LD出力を検証するテストを追加

## Test plan

- [x] `npx vitest run app/src/data/structured_data/` で2テストがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)