### PR TITLE
test: add unit tests for optout API endpoint

### DIFF
--- a/app/src/pages/api/optout.test.ts
+++ b/app/src/pages/api/optout.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { GET, POST } from './optout';
+
+function createCookiesStub(initialCookies: Record<string, string> = {}): {
+  has: (key: string) => boolean;
+  set: (key: string, value: string) => Map<string, string>;
+  delete: (key: string) => boolean;
+} {
+  const store = new Map(Object.entries(initialCookies));
+  return {
+    has: (key: string) => store.has(key),
+    set: (key: string, value: string) => store.set(key, value),
+    delete: (key: string) => store.delete(key),
+  };
+}
+
+describe('GET /api/optout', () => {
+  it('returns { enabled: false } without cookie', async () => {
+    // Act
+    const response = GET({ cookies: createCookiesStub() } as never);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ enabled: false });
+  });
+
+  it('returns { enabled: true } with cookie', async () => {
+    // Act
+    const response = GET({ cookies: createCookiesStub({ analytics_optout_enabled: 'true' }) } as never);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ enabled: true });
+  });
+});
+
+describe('POST /api/optout', () => {
+  it('sets cookie and returns 200 without cookie', async () => {
+    // Arrange
+    const cookies = createCookiesStub();
+
+    // Act
+    const response = POST({ cookies } as never);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ message: 'Cookie is created.' });
+    expect(cookies.has('analytics_optout_enabled')).toBe(true);
+  });
+
+  it('deletes cookie and returns 204 with cookie', () => {
+    // Arrange
+    const cookies = createCookiesStub({ analytics_optout_enabled: 'true' });
+
+    // Act
+    const response = POST({ cookies } as never);
+
+    // Assert
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+    expect(cookies.has('analytics_optout_enabled')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The optout API endpoint (`/api/optout`) had no test coverage. As part of an ongoing effort to add behavior-focused tests to untested endpoints, this PR adds unit tests for both the GET and POST handlers.

Tests assert observable behavior (response status codes, response bodies, and cookie store state changes) without relying on mock call argument assertions. The cookies dependency is stubbed with a minimal Map-backed implementation rather than spy-based mocks.

## Changes

- Add unit tests for GET/POST `/api/optout` covering all 4 code paths (cookie present/absent for each method)

## Test plan

- [x] `npx vitest run app/src/pages/api/optout.test.ts` : 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)