### PR TITLE
ci: use GitHub App token for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,17 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -33,4 +43,4 @@ jobs:
       - name: Release script
         run: npx semantic-release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Branch protection rulesでmainブランチに4つのstatus check（lint, e2e, test, check）を必須としているが、semantic-releaseの`@semantic-release/git`がCHANGELOGやpackage.jsonの更新をmainに直接pushする際、これらのcheckが未実行のため拒否されていた。

デフォルトの`GITHUB_TOKEN`にはbranch protectionをbypassする権限がないため、専用のGitHub App tokenを使用する方式に切り替えた。[kubosho/configs](https://github.com/kubosho/configs)リポジトリで同じ方式が稼働しており、それに合わせた構成にしている。

## Changes

- GitHub App tokenの生成ステップを追加し、semantic-releaseの認証をデフォルトの`GITHUB_TOKEN`からApp tokenに切り替え
- checkoutで`persist-credentials: false`を指定（App tokenでのpushを優先させるため）

## Test plan

- [x] `RELEASE_APP_ID`と`RELEASE_APP_PRIVATE_KEY`のsecretsを設定済み
- [x] GitHub AppをRulesetsのbypass listに追加済み
- [ ] マージ後、Releaseワークフローがmainへのpushに成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)