### PR TITLE
style: improve typography, link hover, theme toggle, footer, and code block styles

### DIFF
--- a/app/src/components/ThemeSwitcher.astro
+++ b/app/src/components/ThemeSwitcher.astro
@@ -22,9 +22,8 @@ const darkLabel = retrieveTranslation('components.themeSwitcher.dark');
 
 <style>
   .TriggerButton {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    place-items: center;
     padding: var(--space-component-1);
     border: none;
     border-radius: var(--border-radius);
@@ -39,27 +38,36 @@ const darkLabel = retrieveTranslation('components.themeSwitcher.dark');
 
   .IconSun,
   .IconMoon {
-    display: none;
+    grid-area: 1 / 1;
+    opacity: 0;
+    transition: opacity 0.2s ease;
   }
 
   :global([data-theme='system']) .IconSun {
-    display: block;
+    opacity: 1;
   }
   @media (prefers-color-scheme: dark) {
     :global([data-theme='system']) .IconSun {
-      display: none;
+      opacity: 0;
     }
     :global([data-theme='system']) .IconMoon {
-      display: block;
+      opacity: 1;
     }
   }
 
   :global([data-theme='light']) .IconSun {
-    display: block;
+    opacity: 1;
   }
 
   :global([data-theme='dark']) .IconMoon {
-    display: block;
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .IconSun,
+    .IconMoon {
+      transition: none;
+    }
   }
 
   .Popover {

--- a/app/src/layouts/GlobalFooter.astro
+++ b/app/src/layouts/GlobalFooter.astro
@@ -11,10 +11,15 @@ import RssIcon from '../assets/rss.svg';
     width: 100%;
     max-width: inherit;
     padding: var(--space-component-1);
+    padding-bottom: calc(var(--space-component-1) + env(safe-area-inset-bottom, 0px));
     border-radius: var(--border-radius);
     margin: var(--space-component-6) auto 0;
     background-color: rgb(from var(--color-primary-main) r g b / 0.99);
     color: var(--color-monotone-50);
+  }
+
+  .Footer small {
+    font-size: inherit;
   }
 
   .Footer > *:not(:first-child) {

--- a/app/src/layouts/GlobalHeader.astro
+++ b/app/src/layouts/GlobalHeader.astro
@@ -22,7 +22,7 @@ const blogDescription = retrieveTranslation('website.description');
     max-width: inherit;
     margin: 0 auto;
     font-size: var(--font-size-text);
-    line-height: calc(var(--line-height-text) * 0.8);
+    line-height: calc(var(--line-height-text) * 0.7);
   }
 
   .Header > h1 {

--- a/app/src/styles/main.css
+++ b/app/src/styles/main.css
@@ -17,7 +17,7 @@ html {
   color: var(--color-neutral-text);
   font-family: var(--font-family-gothic);
   font-size: 100%;
-  font-weight: 300;
+  font-weight: 400;
   line-break: strict;
   line-height: var(--line-height-text);
   transition:
@@ -35,6 +35,16 @@ html {
 
 a {
   text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+  transition: text-decoration-thickness 0.2s ease;
+}
+a:hover {
+  text-decoration-thickness: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  a {
+    transition: none;
+  }
 }
 
 a:is(:link, :visited) {
@@ -117,7 +127,7 @@ h4 {
 }
 
 ul li::marker {
-  color: var(--color-primary-main);
+  color: var(--color-primary-accent);
 }
 
 [data-theme='dark'] :is(.astro-code, .astro-code span) {

--- a/app/src/styles/variables.css
+++ b/app/src/styles/variables.css
@@ -52,6 +52,6 @@
   --line-height-heading-2: calc(var(--line-height-base) * 17 / 8);
   --line-height-heading-3: calc(var(--line-height-base) * 13 / 8);
   --line-height-heading-4: calc(var(--line-height-base) * 11 / 8);
-  --line-height-text: calc(var(--line-height-base) * 13 / 8);
-  --line-height-note: calc(var(--line-height-base) * 11 / 8);
+  --line-height-text: calc(var(--line-height-base) * 13 / 7);
+  --line-height-note: calc(var(--line-height-base) * 11 / 7);
 }


### PR DESCRIPTION
## Summary

ブログのデザインレビューで洗い出した可読性・インタラクション・視覚的一貫性の課題に対応する。

## Changes

- 本文のfont-weight 300→400、line-heightの分母を8→7に変更（日本語テキストの可読性向上）
- GlobalHeaderのline-height乗数を0.8→0.7に変更
- リンクhoverにtext-decoration-thicknessのtransition追加（prefers-reduced-motion対応）
- テーマ切り替えアイコンをdisplay切り替えからopacity+CSS grid重ね合わせに変更（フェードtransition）
- リストマーカーのカラーをprimary-accentに変更（blockquoteとの一貫性）
- フッターのsafe-area対応とsmall要素のfont-size正規化

## Screenshots

| ページ | デスクトップ | モバイル |
| --- | --- | --- |
| トップ | <img width="1280" height="1143" alt="screenshot-top-desktop" src="https://github.com/user-attachments/assets/5d1b0e83-c2e3-47b7-886a-d7a3c8cc2adf" /> | <img width="375" height="1396" alt="screenshot-top-mobile" src="https://github.com/user-attachments/assets/aa11bed9-2af8-4a57-b9e2-aedc4a456949" /> |
| 記事 | <img width="1280" height="5557" alt="screenshot-article-desktop" src="https://github.com/user-attachments/assets/f8ba5db4-deda-42c4-af9c-59bda68597e8" /> | <img width="375" height="8401" alt="screenshot-article-mobile" src="https://github.com/user-attachments/assets/7a868454-575a-4a86-8121-e892e1c1afd3" /> |
| タグ | <img width="1280" height="800" alt="screenshot-tag-desktop" src="https://github.com/user-attachments/assets/e5419822-05f3-4e0f-ad2d-62967fc5c490" /> | <img width="375" height="812" alt="screenshot-tag-mobile" src="https://github.com/user-attachments/assets/c5c26677-2d91-4c36-8239-43477ca02451" /> |
| ポリシー | <img width="1280" height="1475" alt="screenshot-policy-desktop" src="https://github.com/user-attachments/assets/2f884cc5-7a87-4a89-a98f-0c9ec1c1c231" /> | <img width="375" height="2010" alt="screenshot-policy-mobile" src="https://github.com/user-attachments/assets/9f9c369e-d048-4593-87fa-46b3cf39f8b1" /> |

## Test plan

- [x] `npm run build` 成功
- [x] トップページ・記事ページ・タグページ・ポリシーページのデスクトップ/モバイル表示を目視確認（screenshot添付）
