### PR TITLE
revert: undo locals.runtime migration (#2764, #2765)

### DIFF
--- a/app/src/features/likes/api/likeActions.ts
+++ b/app/src/features/likes/api/likeActions.ts
@@ -1,3 +1,4 @@
+import type { APIContext } from 'astro';
 import { eq, sql, sum } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 
@@ -5,30 +6,30 @@ import { getDatabaseUrl } from '../utils/getDatabaseUrl';
 import { createDatabaseClient } from './database';
 import { likes } from './likesTable';
 
-type Env = Parameters<typeof getDatabaseUrl>[0];
+type Context = APIContext['locals'];
 
 type GetLikeCountsParams = {
   entryId: string | null | undefined;
-  env?: Env;
+  context?: Context;
 };
 
 type IncrementLikeCountsParams = {
   increment: number;
   entryId: string;
-  env?: Env;
+  context?: Context;
 };
 
-function getDb(env?: Env): PostgresJsDatabase {
-  const databaseUrl = getDatabaseUrl(env);
+function getDb(context?: Context): PostgresJsDatabase {
+  const databaseUrl = getDatabaseUrl(context);
   return createDatabaseClient(databaseUrl);
 }
 
-export async function getLikeCounts({ entryId, env }: GetLikeCountsParams): Promise<number> {
+export async function getLikeCounts({ context, entryId }: GetLikeCountsParams): Promise<number> {
   if (entryId == null) {
     return 0;
   }
 
-  const db = getDb(env);
+  const db = getDb(context);
   const result = await db
     .select({
       total: sum(likes.counts),
@@ -41,8 +42,8 @@ export async function getLikeCounts({ entryId, env }: GetLikeCountsParams): Prom
   return total;
 }
 
-export async function incrementLikeCounts({ entryId, increment, env }: IncrementLikeCountsParams): Promise<number> {
-  const db = getDb(env);
+export async function incrementLikeCounts({ context, entryId, increment }: IncrementLikeCountsParams): Promise<number> {
+  const db = getDb(context);
 
   const result = await db
     .insert(likes)

--- a/app/src/features/likes/utils/getDatabaseUrl.ts
+++ b/app/src/features/likes/utils/getDatabaseUrl.ts
@@ -1,17 +1,17 @@
-type Env = {
-  DATABASE_URL?: string;
-  HYPERDRIVE?: { connectionString: string };
-};
+import type { APIContext } from 'astro';
 
-export function getDatabaseUrl(env?: Env): string | undefined {
-  const connectionString = env?.HYPERDRIVE?.connectionString;
+export function getDatabaseUrl(context?: APIContext['locals']): string | undefined {
+  // Cloudflare environment
+  const connectionString = context?.runtime?.env?.HYPERDRIVE?.connectionString;
   if (connectionString != null && connectionString !== '') {
     return connectionString;
   }
 
-  if (env?.DATABASE_URL != null && env.DATABASE_URL !== '') {
-    return env.DATABASE_URL;
+  // Fallback for Astro environment
+  if (context?.runtime?.env?.DATABASE_URL != null && context.runtime.env.DATABASE_URL !== '') {
+    return context.runtime.env.DATABASE_URL;
   }
 
+  // Fallback for Node.js environment
   return process.env.DATABASE_URL;
 }

--- a/app/src/pages/api/likes/[id].ts
+++ b/app/src/pages/api/likes/[id].ts
@@ -1,8 +1,4 @@
-import type {
-  CacheStorage as CFCacheStorage,
-  RateLimit,
-  Response as CFResponse,
-} from '@cloudflare/workers-types/experimental';
+import type { Cache, Response as CFResponse } from '@cloudflare/workers-types/experimental';
 import type { APIContext } from 'astro';
 import { getEntry } from 'astro:content';
 import { parse, ValiError } from 'valibot';
@@ -21,15 +17,9 @@ export const prerender = false;
 const COOLDOWN_PERIOD_SECONDS = 30;
 const EDGE_CACHE_TTL_SECONDS = 60;
 
-type CloudflareEnv = {
-  DATABASE_URL?: string;
-  HYPERDRIVE?: { connectionString: string };
-  LIKES_RATE_LIMITER?: RateLimit;
-};
-
-async function getCloudflareEnv(): Promise<CloudflareEnv> {
-  const { env } = await import('cloudflare:workers');
-  return env as unknown as CloudflareEnv;
+function getCache({ locals }: Pick<APIContext, 'locals'>): Cache | null {
+  const cache = locals.runtime?.caches?.default ?? null;
+  return cache;
 }
 
 function createNormalizedCacheKey(request: Request): string {
@@ -38,7 +28,7 @@ function createNormalizedCacheKey(request: Request): string {
   return url.toString();
 }
 
-export async function GET({ params, request }: APIContext): Promise<Response> {
+export async function GET({ locals, params, request }: APIContext): Promise<Response> {
   const { id } = params;
   if (!isValidEntryIdFormat(id)) {
     return createClientErrorResponse({ type: 'invalidEntryId' });
@@ -53,10 +43,10 @@ export async function GET({ params, request }: APIContext): Promise<Response> {
     return createServerErrorResponse({ error });
   }
 
-  const cache = (caches as unknown as CFCacheStorage).default;
+  const cache = getCache({ locals });
   const cacheKey = createNormalizedCacheKey(request);
 
-  const cachedResponse = await cache.match(cacheKey);
+  const cachedResponse = await cache?.match(cacheKey);
   if (cachedResponse != null) {
     const body = await cachedResponse.text();
     return new Response(body, {
@@ -66,8 +56,10 @@ export async function GET({ params, request }: APIContext): Promise<Response> {
   }
 
   try {
-    const cfEnv = await getCloudflareEnv();
-    const counts = await getLikeCounts({ entryId: id, env: cfEnv });
+    const counts = await getLikeCounts({
+      context: locals,
+      entryId: id,
+    });
 
     const response = new Response(
       JSON.stringify({
@@ -83,7 +75,7 @@ export async function GET({ params, request }: APIContext): Promise<Response> {
       },
     );
 
-    await cache.put(cacheKey, response.clone() as CFResponse);
+    await cache?.put(cacheKey, response.clone() as CFResponse);
 
     return response;
   } catch (error) {
@@ -91,7 +83,7 @@ export async function GET({ params, request }: APIContext): Promise<Response> {
   }
 }
 
-export async function POST({ params, request }: APIContext): Promise<Response> {
+export async function POST({ locals, params, request }: APIContext): Promise<Response> {
   const { id } = params;
   if (!isValidEntryIdFormat(id)) {
     return createClientErrorResponse({ type: 'invalidEntryId' });
@@ -110,14 +102,13 @@ export async function POST({ params, request }: APIContext): Promise<Response> {
     return createClientErrorResponse({ type: 'invalidRequestBody' });
   }
 
-  const cfEnv = await getCloudflareEnv();
-
-  if (cfEnv.LIKES_RATE_LIMITER != null) {
+  const rateLimiterEnv = locals.runtime?.env?.LIKES_RATE_LIMITER;
+  if (rateLimiterEnv != null) {
     const clientIp = getClientIp(request);
     const isRateLimitExceeded = await checkRateLimit({
       clientIp,
       entryId: id,
-      rateLimiter: cfEnv.LIKES_RATE_LIMITER,
+      rateLimiter: rateLimiterEnv,
     });
 
     if (isRateLimitExceeded) {
@@ -133,12 +124,16 @@ export async function POST({ params, request }: APIContext): Promise<Response> {
       return createClientErrorResponse({ type: 'invalidIncrement' });
     }
 
-    await incrementLikeCounts({ entryId: id, increment, env: cfEnv });
+    await incrementLikeCounts({
+      context: locals,
+      increment,
+      entryId: id,
+    });
 
-    const cache = (caches as unknown as CFCacheStorage).default;
+    const cache = getCache({ locals });
     const cacheKey = createNormalizedCacheKey(request);
 
-    await cache.delete(cacheKey);
+    await cache?.delete(cacheKey);
 
     return new Response(
       JSON.stringify({

--- a/app/types.d.ts
+++ b/app/types.d.ts
@@ -1,0 +1,31 @@
+import type {
+  CacheStorage as CloudflareCacheStorage,
+  ExecutionContext,
+  ExportedHandlerFetchHandler,
+  Hyperdrive,
+  RateLimit,
+} from '@cloudflare/workers-types/experimental';
+
+type Env = {
+  readonly DATABASE_URL?: string;
+  readonly HYPERDRIVE?: Hyperdrive;
+  readonly LIKES_RATE_LIMITER?: RateLimit;
+  readonly NODE_ENV?: string;
+};
+
+type CloudflareRuntime<T extends object> = {
+  runtime: {
+    env: Env & T;
+    cf: Parameters<ExportedHandlerFetchHandler>[0]['cf'];
+    caches: CloudflareCacheStorage;
+    ctx: ExecutionContext;
+  };
+};
+
+declare global {
+  declare namespace App {
+    interface Locals {
+      runtime?: CloudflareRuntime<Env>['runtime'];
+    }
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ export default defineConfig([
       'import/no-unresolved': [
         'error',
         {
-          ignore: ['astro:content', 'cloudflare:workers'],
+          ignore: ['astro:content'],
         },
       ],
     },
@@ -50,7 +50,7 @@ export default defineConfig([
       'import/no-unresolved': [
         'error',
         {
-          ignore: ['astro:content', 'cloudflare:workers'],
+          ignore: ['astro:content'],
         },
       ],
     },


### PR DESCRIPTION
## Summary

Reverts the `locals.runtime.caches` and `locals.runtime.env` migration from #2764 and #2765.

`@astrojs/cloudflare` v13 uses a redirected wrangler config (`dist/server/wrangler.json`) that only contains root-level bindings. Environment-specific bindings defined in `wrangler.jsonc` under `env.staging` and `env.production` (Hyperdrive, Rate Limiter) are not included. This caused `cloudflare:workers` env to lack Hyperdrive, making the likes API fall back to a build-time embedded `process.env.DATABASE_URL` that fails on Cloudflare Workers.

The Astro v6 package upgrade and `wrangler.jsonc` `main` field removal from #2764 are kept. Only the runtime API changes (`locals.runtime` → `cloudflare:workers` / global `caches`) are reverted.

## Changes

- Revert `getDatabaseUrl` to accept `APIContext["locals"]` and use `locals.runtime.env`
- Revert `likeActions` to pass `context` instead of `env`
- Revert `[id].ts` to use `locals.runtime.caches` and `locals.runtime.env`
- Restore `types.d.ts` with `CloudflareRuntime` type
- Remove `cloudflare:workers` from ESLint `import/no-unresolved` ignore

## Test plan

- [x] `npm run build` — succeeds
- [x] `npm test` — 24 files, 84 tests passed
- [x] `npm run check:type` — 0 errors
- [ ] Deploy to staging and verify `/api/likes/[id]` returns counts