### PR TITLE
fix: limit SWR error retry count to prevent continuous Sentry alerts

### DIFF
--- a/app/src/features/likes/hooks/useLikes.ts
+++ b/app/src/features/likes/hooks/useLikes.ts
@@ -29,6 +29,7 @@ export function useLikes({ entryId }: UseLikeParams): UseLikeReturn {
   const { data, isLoading, mutate } = useSWR<LikesOnGetResponse | null>(`/api/likes/${entryId}`, fetcher, {
     revalidateOnFocus: false,
     revalidateOnReconnect: false,
+    errorRetryCount: 3,
     onError(error) {
       Sentry.captureException(error, {
         tags: { component: 'useLikes' },


### PR DESCRIPTION
## Summary

PR #2772 migrated Sentry to `@sentry/astro` and added `captureException` in the SWR `onError` handler for the likes API GET requests. However, SWR retries on error indefinitely by default, so when the API returns persistent errors (e.g., database outage), Sentry alerts fire continuously in an infinite loop.

Setting `errorRetryCount: 3` caps retries so transient failures can still recover while preventing an endless cycle of alerts.

## Changes

- Add error retry limit to SWR likes fetcher (unlimited by default → 3 retries)

## Test plan

- [x] Open an entry page in dev environment and confirm retries stop after 3 attempts when the likes API fails
- [x] Confirm errors are reported to Sentry without repeating indefinitely