### PR TITLE
fix: filter out bot traffic from Sentry error reporting

### DIFF
--- a/app/sentry.client.config.ts
+++ b/app/sentry.client.config.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
+const BOT_USER_AGENT_PATTERN = /bot|crawl|spider|slurp|bingpreview|mediapartners|headlesschrome/i;
+
 Sentry.init({
   dsn: import.meta.env.PUBLIC_SENTRY_DSN,
   environment: import.meta.env.MODE,
@@ -13,4 +15,10 @@ Sentry.init({
   tracesSampleRate: 1.0,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
+  beforeSend(event) {
+    if (BOT_USER_AGENT_PATTERN.test(navigator.userAgent)) {
+      return null;
+    }
+    return event;
+  },
 });


### PR DESCRIPTION
## Summary

After enabling Sentry via #2772, alerts started firing continuously from bot traffic. The user info showed Chrome 145 on Windows from Boydton, Virginia — a known data center location for Microsoft/Meta, indicating crawler or bot access. Bots that execute JavaScript trigger the likes API fetch, which fails and reports to Sentry repeatedly.

Adding a `beforeSend` filter that drops events when the User-Agent matches known bot patterns prevents this noise from reaching Sentry.

## Changes

- Add `beforeSend` hook to Sentry client config that discards events from bot User-Agents

## Test plan

- [x] Verify Sentry init includes `beforeSend` in dev build
- [x] Confirm real browser events are still reported to Sentry