### PR TITLE
test: improve API test quality based on test principles

### DIFF
--- a/app/src/pages/api/optout.test.ts
+++ b/app/src/pages/api/optout.test.ts
@@ -46,7 +46,6 @@ describe('POST /api/optout', () => {
     // Assert
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ message: 'Cookie is created.' });
-    expect(cookies.has('analytics_optout_enabled')).toBe(true);
   });
 
   it('deletes cookie and returns 204 with cookie', () => {
@@ -59,6 +58,5 @@ describe('POST /api/optout', () => {
     // Assert
     expect(response.status).toBe(204);
     expect(response.body).toBeNull();
-    expect(cookies.has('analytics_optout_enabled')).toBe(false);
   });
 });

--- a/app/src/pages/api/theme.test.ts
+++ b/app/src/pages/api/theme.test.ts
@@ -43,7 +43,7 @@ describe('GET /api/theme', () => {
     expect(await response.json()).toEqual({ theme: 'system' });
   });
 
-  it('returns the cookie value as theme', async () => {
+  it('returns { theme: "dark" } when theme cookie is dark', async () => {
     // Arrange
     const cookies = createCookiesStub(new Map([['theme', 'dark']]));
 
@@ -57,7 +57,7 @@ describe('GET /api/theme', () => {
 });
 
 describe('POST /api/theme', () => {
-  it('sets cookie and returns the theme for dark', async () => {
+  it('returns { theme: "dark" } when setting dark theme', async () => {
     // Arrange
     const cookies = createCookiesStub();
     const request = postRequest(JSON.stringify({ theme: 'dark' }));
@@ -68,10 +68,22 @@ describe('POST /api/theme', () => {
     // Assert
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ theme: 'dark' });
-    expect(cookies.set).toHaveBeenCalledOnce();
   });
 
-  it('deletes cookie and returns system for system theme', async () => {
+  it('returns { theme: "light" } when setting light theme', async () => {
+    // Arrange
+    const cookies = createCookiesStub();
+    const request = postRequest(JSON.stringify({ theme: 'light' }));
+
+    // Act
+    const response = await POST({ cookies, request } as unknown as APIContext);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ theme: 'light' });
+  });
+
+  it('returns { theme: "system" } when resetting to system theme', async () => {
     // Arrange
     const cookies = createCookiesStub(new Map([['theme', 'dark']]));
     const request = postRequest(JSON.stringify({ theme: 'system' }));
@@ -82,7 +94,6 @@ describe('POST /api/theme', () => {
     // Assert
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ theme: 'system' });
-    expect(cookies.delete).toHaveBeenCalledOnce();
   });
 
   it('returns 400 for invalid theme value', async () => {


### PR DESCRIPTION
## Summary

API route tests for optout and theme endpoints were asserting internal cookie method calls (`cookies.has`, `cookies.set`, `cookies.delete`) rather than the HTTP response contract. These process assertions couple tests to implementation details, making them fragile to refactoring. This change aligns the tests with the principle of asserting results over process.

Additionally, test names were vague in places (e.g. "returns the cookie value as theme") and the light theme POST case was missing entirely.

## Changes

- Removed process assertions (`cookies.has`/`set`/`delete` call checks) from optout and theme tests
- Renamed vague test names to state concrete input and expected output
- Added `light` theme POST test case to cover the missing valid theme value

## Test plan

- [x] `npx vitest run src/pages/api/optout.test.ts src/pages/api/theme.test.ts` passes all 11 tests (4 optout + 7 theme)