### PR TITLE
ci: cache Playwright browsers in e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,26 @@ jobs:
       - name: Install modules
         run: npm ci
 
+      - name: Get installed Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+        working-directory: app
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: app
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: app
 
       - name: Run E2E tests


### PR DESCRIPTION
## Summary

Cache ~/.cache/ms-playwright keyed on the installed Playwright version so the browser binaries are restored instead of re-downloaded on every run.

The 'Install Playwright browsers' step (full download via cdn.playwright.dev) is the step that hangs in CI; on a cache hit we only run install-deps for the system libraries, avoiding the download entirely.