### PR TITLE
ci: add timeout-minutes to e2e job to fail fast on hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
 
     needs: [lint, check]
 
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## 概要

E2Eテストの `e2e` ジョブが「Install Playwright browsers」ステップ（`npx playwright install --with-deps chromium`）でハングする問題への**一時対策**です。

## 背景

直近のCI runを調査したところ、`e2e` ジョブが Chrome のダウンロード完了（100%）直後にハングし、後続の `Run E2E tests` に到達できていませんでした。ジョブに `timeout-minutes` の指定がないため、GitHub Actions のデフォルトである **360分（6時間）** までキャンセルされず、CI時間を浪費していました。

実例:
- run 27452971970: `Install Playwright browsers` が 01:50:01 開始 → 07:49:49 にキャンセル（**ちょうど6時間 = 360分のデフォルトタイムアウト**）

## 変更内容

`e2e` ジョブに `timeout-minutes: 15` を追加し、ブラウザインストールがハングした場合に素早く失敗させます。

```yaml
  e2e:
    runs-on: ubuntu-latest
    needs: [lint, check]
    timeout-minutes: 15
```

## 注意

これはハングの根本原因を解消するものではなく、**ハングを早期に検知・失敗させるための応急処置**です。根本対策（Playwrightブラウザのキャッシュ導入）は別ブランチ `claude/e2e-playwright-browser-cache-b9ym6t` で対応しています。

https://claude.ai/code/session_0153faS9dUVvRYr8UcqYL9PY

---
_Generated by [Claude Code](https://claude.ai/code/session_0153faS9dUVvRYr8UcqYL9PY)_