### PR TITLE
fix: avoid provisioning unused session KV

### DIFF
--- a/app/astro.config.ts
+++ b/app/astro.config.ts
@@ -3,7 +3,7 @@ import mdx from '@astrojs/mdx';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import sentry from '@sentry/astro';
-import { defineConfig, passthroughImageService } from 'astro/config';
+import { defineConfig, passthroughImageService, sessionDrivers } from 'astro/config';
 
 import { SITE_URL } from './constants/siteData';
 
@@ -30,6 +30,11 @@ export default defineConfig({
     },
   },
   output: 'static',
+  // The app does not use Astro.server sessions. Make the driver explicit so
+  // @astrojs/cloudflare does not auto-provision a SESSION KV namespace at deploy time.
+  session: {
+    driver: sessionDrivers.lruCache(),
+  },
   site: SITE_URL,
   vite: {
     define: {


### PR DESCRIPTION
Cloudflare のデプロイは build までは完了していましたが、deploy phase で Astro/Cloudflare adapter が `SESSION` KV namespace を自動 provisioning しようとして失敗していました。今回の app では Astro の server sessions は使っておらず、既に存在する `blog-session` namespace と deploy 時の自動作成が衝突していたことが直接の原因です。

この PR では session driver を明示し、Cloudflare adapter が未使用の `SESSION` KV binding を生成しないようにします。

Cloudflare へ実際にデプロイをする代わりに Wrangler の production/staging dry-run で生成済み Worker の binding 一覧を確認し、`SESSION` KV が消えていることを確認しました。

## Test plan
- [x] `npm run check:type -w app`
- [x] `npm run lint:script -w app`
- [x] `npm run build:prd -w app`
- [x] `npx wrangler deploy --env production --dry-run`
- [x] `npm run build:stg -w app`
- [x] `npx wrangler deploy --env staging --dry-run`