### PR TITLE
ci: serialize Release job runs to avoid push races

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
+    # Serializes duplicate runs so a second run's `git push` doesn't race the first
+    # and fail with a non-fast-forward rejection.
+    concurrency:
+      group: release
+
     steps:
       - name: Generate Token
         id: app-token


### PR DESCRIPTION
## Overview

After merging #2978, the Release workflow still failed on some pushes to `main` — but for a different reason than before.

## Cause

In [this failed run](https://github.com/kubosho/blog.kubosho.com/actions/runs/33479253934/job/99764971335), `generateNotes` succeeded, confirming the previous fix works. The failure was instead in `@semantic-release/git`'s `prepare` step:

```
! [rejected]          HEAD -> main (fetch first)
```

Checking the Release runs for that push, two separate runs started one second apart for the same commit, both triggered by `workflow_run`. Only one CI run actually completed for that push, so GitHub delivered a duplicate `workflow_run: completed` event and started the Release job twice. The first run to reach `git push` wins; the second finds `main` has already moved and fails with a non-fast-forward rejection — even though a release was successfully published moments earlier by the other run.

## Fix

Add a `concurrency` group to the `release` job so duplicate runs queue instead of racing. A queued run's checkout picks up the first run's commit and tag, so `analyzeCommits` finds nothing left to release and the job exits cleanly instead of failing on `git push`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQjbtrZVp2Ax1aAkHUZmuN)_